### PR TITLE
[JENKINS-40899] Verifying comparisons between a private snapshot build and a cleaned-up version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.24</version>
+    <version>1.37</version>
+    <relativePath/>
   </parent>
 
   <artifactId>version-number</artifactId>
@@ -18,6 +19,12 @@
       <version>3.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>test-annotations</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>
@@ -28,14 +35,19 @@
   <licenses>
     <license>
       <name>MIT License</name>
-      <url>http://jenkins-ci.org/mit-license</url>
+      <url>https://opensource.org/licenses/MIT</url>
     </license>
   </licenses>
 
   <repositories>
     <repository>
-      <id>m.g.o-public</id>
-      <url>http://maven.glassfish.org/content/groups/public/</url>
+      <id>repo.jenkins-ci.org</id>
+      <url>http://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
 </project>

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -24,6 +24,7 @@
 package hudson.util;
 
 import junit.framework.TestCase;
+import org.jvnet.hudson.test.Issue;
 
 /**
  * @author Xavier Le Vourch
@@ -49,10 +50,12 @@ public class VersionNumberTest extends TestCase {
        assertTrue(new VersionNumber("2.0.ea1").isNewerThan(new VersionNumber("2.0.ea")));
        assertEquals(new VersionNumber("2.0.ea"), new VersionNumber("2.0.ea0"));
     }
-    
+
+    @Issue("JENKINS-40899")
     public void testSnapshots() {
         assertTrue(new VersionNumber("1.12").isNewerThan(new VersionNumber("1.12-SNAPSHOT (private-08/24/2008 12:13-hudson)")));
         assertTrue(new VersionNumber("1.12-SNAPSHOT (private-08/24/2008 12:13-hudson)").isNewerThan(new VersionNumber("1.11")));
+        assertTrue(new VersionNumber("1.12-SNAPSHOT (private-08/24/2008 12:13-hudson)").isNewerThan(new VersionNumber("1.12-SNAPSHOT")));
         // This is changed from the old impl because snapshots are no longer a "magic" number
         assertFalse(new VersionNumber("1.12-SNAPSHOT").equals(new VersionNumber("1.11.*")));
         assertTrue(new VersionNumber("1.11.*").isNewerThan(new VersionNumber("1.11.9")));


### PR DESCRIPTION
[JENKINS-40899](https://issues.jenkins-ci.org/browse/JENKINS-40899)

Supposedly https://github.com/jenkinsci/maven-hpi-plugin/pull/46 helps snapshot comparisons; adding a test about what that kind of comparison (in `PluginWrapper.isDependencyObsolete`) should look like.

@reviewbybees