### PR TITLE
VersionNumber.digit() does not work as expected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.ipr
 *.iws
 target
+/.idea/

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -514,10 +514,10 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     /**
-     * Returns a digit (numeric component) by its position
+     * Returns a digit (numeric component) by its position.
      *
      * @param idx Digit position we want to retrieve starting by 1 (not zero).
-     * @return The digit or -1 in case the position does not correspond with a digit
+     * @return The digit or -1 in case the position does not correspond with a digit.
      */
     public int digit(int idx) {
         if (idx <= 0) {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -516,7 +516,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
     /**
      * Returns a digit (numeric component) by its position
      *
-     * @param idx Digit position we want to retrieve
+     * @param idx Digit position we want to retrieve starting by 1 (not zero).
      * @return The digit or -1 in case the position does not correspond with a digit
      */
     public int digit(int idx) {
@@ -529,7 +529,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
             }
         }
         try {
-            return ((IntegerItem) item).value.intValue();
+            return (idx > 0) ? -1 : ((IntegerItem) item).value.intValue();
         } catch (ClassCastException cast) {
             return -1;
         }

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -514,15 +514,30 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     /**
+     * @deprecated see {@link #getDigitAt(int)}
+     */
+    public int digit(int idx) {
+        Iterator i = items.iterator();
+        Item item = (Item) i.next();
+        while (idx > 0 && i.hasNext()) {
+            if (item instanceof IntegerItem) {
+                idx--;
+            }
+            i.next();
+        }
+        return ((IntegerItem) item).value.intValue();
+    }
+
+    /**
      * Returns a digit (numeric component) by its position. Once a non-numeric component is found all remaining components
      * are also considered non-numeric by this method.
      *
-     * @param idx Digit position we want to retrieve starting by 1 (not zero).
+     * @param idx Digit position we want to retrieve starting by 0.
      * @return The digit or -1 in case the position does not correspond with a digit.
      */
-    public int digit(int idx) {
+    public int getDigitAt(int idx) {
         Iterator it = items.iterator();
-        int i = 1;
+        int i = 0;
         Item item = null;
         while (i <= idx && it.hasNext()) {
             item  = (Item) it.next();
@@ -532,7 +547,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
                 return -1;
             }
         }
-        return ((idx <= 0) || (idx - i > 0)) ? -1 : ((IntegerItem) item).value.intValue();
+        return ((idx < 0) || (idx - i >= 0)) ? -1 : ((IntegerItem) item).value.intValue();
     }
 
     public static final Comparator<VersionNumber> DESCENDING = new Comparator<VersionNumber>() {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -513,16 +513,26 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return compareTo(rhs) > 0;
     }
 
+    /**
+     * Returns a digit (numeric component) by its position
+     *
+     * @param idx Digit position we want to retrieve
+     * @return The digit or -1 in case the position does not correspond with a digit
+     */
     public int digit(int idx) {
         Iterator i = items.iterator();
-        Item item = (Item) i.next();
+        Item item = null;
         while (idx > 0 && i.hasNext()) {
+            item  = (Item) i.next();
             if (item instanceof IntegerItem) {
                 idx--;
             }
-            i.next();
         }
-        return ((IntegerItem) item).value.intValue();
+        try {
+            return ((IntegerItem) item).value.intValue();
+        } catch (ClassCastException cast) {
+            return -1;
+        }
     }
 
     public static final Comparator<VersionNumber> DESCENDING = new Comparator<VersionNumber>() {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -520,6 +520,9 @@ public class VersionNumber implements Comparable<VersionNumber> {
      * @return The digit or -1 in case the position does not correspond with a digit
      */
     public int digit(int idx) {
+        if (idx <= 0) {
+            return -1;
+        }
         Iterator i = items.iterator();
         Item item = null;
         while (idx > 0 && i.hasNext()) {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -536,6 +536,10 @@ public class VersionNumber implements Comparable<VersionNumber> {
      * @return The digit or -1 in case the position does not correspond with a digit.
      */
     public int getDigitAt(int idx) {
+        if (idx < 0) {
+            return -1;
+        }
+
         Iterator it = items.iterator();
         int i = 0;
         Item item = null;
@@ -547,7 +551,7 @@ public class VersionNumber implements Comparable<VersionNumber> {
                 return -1;
             }
         }
-        return ((idx < 0) || (idx - i >= 0)) ? -1 : ((IntegerItem) item).value.intValue();
+        return (idx - i >= 0) ? -1 : ((IntegerItem) item).value.intValue();
     }
 
     public static final Comparator<VersionNumber> DESCENDING = new Comparator<VersionNumber>() {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -520,22 +520,18 @@ public class VersionNumber implements Comparable<VersionNumber> {
      * @return The digit or -1 in case the position does not correspond with a digit.
      */
     public int digit(int idx) {
-        if (idx <= 0) {
-            return -1;
-        }
-        Iterator i = items.iterator();
+        Iterator it = items.iterator();
+        int i = 1;
         Item item = null;
-        while (idx > 0 && i.hasNext()) {
-            item  = (Item) i.next();
+        while (i <= idx && it.hasNext()) {
+            item  = (Item) it.next();
             if (item instanceof IntegerItem) {
-                idx--;
+                i++;
+            } else {
+                return -1;
             }
         }
-        try {
-            return (idx > 0) ? -1 : ((IntegerItem) item).value.intValue();
-        } catch (ClassCastException cast) {
-            return -1;
-        }
+        return ((idx <= 0) || (idx - i > 0)) ? -1 : ((IntegerItem) item).value.intValue();
     }
 
     public static final Comparator<VersionNumber> DESCENDING = new Comparator<VersionNumber>() {

--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -514,7 +514,8 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     /**
-     * Returns a digit (numeric component) by its position.
+     * Returns a digit (numeric component) by its position. Once a non-numeric component is found all remaining components
+     * are also considered non-numeric by this method.
      *
      * @param idx Digit position we want to retrieve starting by 1 (not zero).
      * @return The digit or -1 in case the position does not correspond with a digit.

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -82,5 +82,6 @@ public class VersionNumberTest extends TestCase {
         assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").digit(5));
         assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").digit(4));
         assertEquals(-1, new VersionNumber("2.0.3").digit(5));
+        assertEquals(-1, new VersionNumber("2.0.3").digit(0));
     }
 }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -73,17 +73,18 @@ public class VersionNumberTest extends TestCase {
     }
 
     public void testDigit() {
-        assertEquals(2, new VersionNumber("2.32.3.1-SNAPSHOT").digit(1));
-        assertEquals(32, new VersionNumber("2.32.3.1-SNAPSHOT").digit(2));
-        assertEquals(3, new VersionNumber("2.32.3.1-SNAPSHOT").digit(3));
-        assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(4));
-        assertEquals(-1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(5));
-        assertEquals(0, new VersionNumber("2.7.22.0.2").digit(4));
-        assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").digit(5));
-        assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").digit(4));
-        assertEquals(-1, new VersionNumber("2.0.3").digit(5));
-        assertEquals(-1, new VersionNumber("2.0.3").digit(0));
-        assertEquals(-1, new VersionNumber("2.0.3").digit(-1));
-        assertEquals(0, new VersionNumber("1.0.0.GA.2-3").digit(3));
+        assertEquals(32, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(1));
+        assertEquals(3, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(2));
+        assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(3));
+        assertEquals(-1, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(4));
+        assertEquals(2, new VersionNumber("2.7.22.0.2").getDigitAt(4));
+        assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").getDigitAt(4));
+        assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").getDigitAt(4));
+        assertEquals(-1, new VersionNumber("2.0.3").getDigitAt(5));
+        assertEquals(2, new VersionNumber("2.0.3").getDigitAt(0));
+        assertEquals(-1, new VersionNumber("2.0.3").getDigitAt(-1));
+        assertEquals(-1, new VersionNumber("1.0.0.GA.2-3").getDigitAt(3));
+        assertEquals(-1, new VersionNumber("").getDigitAt(-1));
+        assertEquals(-1, new VersionNumber("").getDigitAt(0));
     }
 }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -81,5 +81,6 @@ public class VersionNumberTest extends TestCase {
         assertEquals(0, new VersionNumber("2.7.22.0.2").digit(4));
         assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").digit(5));
         assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").digit(4));
+        assertEquals(-1, new VersionNumber("2.0.3").digit(5));
     }
 }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -71,4 +71,15 @@ public class VersionNumberTest extends TestCase {
         assertFalse(new VersionNumber("2.0.3-20170207.105042-1").isNewerThan(new VersionNumber("2.0.3-SNAPSHOT")));
         assertFalse(new VersionNumber("2.0.3-20170207.105042-1").isOlderThan(new VersionNumber("2.0.3-SNAPSHOT")));
     }
+
+    public void testDigit() {
+        assertEquals(2, new VersionNumber("2.32.3.1-SNAPSHOT").digit(1));
+        assertEquals(32, new VersionNumber("2.32.3.1-SNAPSHOT").digit(2));
+        assertEquals(3, new VersionNumber("2.32.3.1-SNAPSHOT").digit(3));
+        assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(4));
+        assertEquals(-1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(5));
+        assertEquals(0, new VersionNumber("2.7.22.0.2").digit(4));
+        assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").digit(5));
+        assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").digit(4));
+    }
 }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -83,5 +83,6 @@ public class VersionNumberTest extends TestCase {
         assertEquals(-1, new VersionNumber("2.0.3-20170207.105042-1").digit(4));
         assertEquals(-1, new VersionNumber("2.0.3").digit(5));
         assertEquals(-1, new VersionNumber("2.0.3").digit(0));
+        assertEquals(-1, new VersionNumber("2.0.3").digit(-1));
     }
 }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -84,5 +84,6 @@ public class VersionNumberTest extends TestCase {
         assertEquals(-1, new VersionNumber("2.0.3").digit(5));
         assertEquals(-1, new VersionNumber("2.0.3").digit(0));
         assertEquals(-1, new VersionNumber("2.0.3").digit(-1));
+        assertEquals(0, new VersionNumber("1.0.0.GA.2-3").digit(3));
     }
 }


### PR DESCRIPTION
The first time I used `VersionNumber.digit(int idx)` I expected retrieving the digit of the version number in the position set by `idx`. However, I always retrieved the first digit or `0` with something like `new VersionNumber("");`.

I tried to understand what this method does, but I did not find any logical behavior.

This PR provides some changes (and tests) in order to define (at least) a behavior documented and tested.

@reviewbybees, specially @stephenc and @jglick 