### PR TITLE
Fix digit() behavior and undeprecate

### DIFF
--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -514,16 +514,17 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     /**
-     * @deprecated see {@link #getDigitAt(int)}
+     * Returns the nth integer component of the version string. The first element is index 0. Non-integer items are skipped. Returns the last integer component if the index is too big.
      */
     public int digit(int idx) {
         Iterator i = items.iterator();
         Item item = (Item) i.next();
         while (idx > 0 && i.hasNext()) {
-            if (item instanceof IntegerItem) {
+            Object o = i.next();
+            if (o instanceof IntegerItem) {
                 idx--;
+                item = (Item) o;
             }
-            i.next();
         }
         return ((IntegerItem) item).value.intValue();
     }

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -72,7 +72,7 @@ public class VersionNumberTest extends TestCase {
         assertFalse(new VersionNumber("2.0.3-20170207.105042-1").isOlderThan(new VersionNumber("2.0.3-SNAPSHOT")));
     }
 
-    public void testDigit() {
+    public void testDigitAt() {
         assertEquals(32, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(1));
         assertEquals(3, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(2));
         assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").getDigitAt(3));
@@ -86,5 +86,19 @@ public class VersionNumberTest extends TestCase {
         assertEquals(-1, new VersionNumber("1.0.0.GA.2-3").getDigitAt(3));
         assertEquals(-1, new VersionNumber("").getDigitAt(-1));
         assertEquals(-1, new VersionNumber("").getDigitAt(0));
+    }
+
+    public void testDigit() {
+        assertEquals(2, new VersionNumber("2.32.3.1-SNAPSHOT").digit(0));
+        assertEquals(32, new VersionNumber("2.32.3.1-SNAPSHOT").digit(1));
+        assertEquals(3, new VersionNumber("2.32.3.1-SNAPSHOT").digit(2));
+        assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(3));
+        assertEquals(1, new VersionNumber("2.32.3.1-SNAPSHOT").digit(4));
+        assertEquals(2, new VersionNumber("2.7.22.0.2").digit(4));
+        assertEquals(3, new VersionNumber("2.7.22.0.3-SNAPSHOT").digit(4));
+        assertEquals(3, new VersionNumber("2.0.3-20170207.105042-1").digit(4)); // 2, 0, 3, snapshot
+        assertEquals(3, new VersionNumber("2.0.3").digit(5));
+        assertEquals(2, new VersionNumber("2.0.3").digit(0));
+        assertEquals(2, new VersionNumber("1.0.0.GA.2-3").digit(3));
     }
 }


### PR DESCRIPTION
Followup (sort of) to #3: It seemed obvious to me how to fix the behavior of `digit()` to actually do something useful. 

So I did.

`i.next()` was never used to update `item`, and since it's not always an `IntegerItem`, needs an intermediate step.

Added tests to ensure behavior as (now) documented.