### PR TITLE
[JENKINS-49203] - Whitelist the library for Jenkins so that VersionNumber is serializable in Jenkins 2.102+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci</groupId>
     <artifactId>jenkins</artifactId>
-    <version>1.37</version>
+    <version>1.39</version>
     <relativePath />
   </parent>
 
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -40,14 +40,31 @@
     </license>
   </licenses>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Jenkins-ClassFilter-Whitelisted>true</Jenkins-ClassFilter-Whitelisted>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <properties>
+    <java.level>7</java.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Noticed it in https://github.com/jenkinsci/jenkins/pull/3263. It seems safe to serialize all classes in the library.

https://issues.jenkins-ci.org/browse/JENKINS-49203

@reviewbybees @jglick @tfennelly 
