### PR TITLE
Add utility method when one also want equality to yield true

### DIFF
--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -524,6 +524,14 @@ public class VersionNumber implements Comparable<VersionNumber> {
         return compareTo(rhs) > 0;
     }
 
+    public boolean isOlderOrEqualTo(VersionNumber rhs) {
+        return compareTo(rhs) <= 0;
+    }
+
+    public boolean isNewerOrEqualTo(VersionNumber rhs) {
+        return compareTo(rhs) >= 0;
+    }
+
     /**
      * @deprecated see {@link #getDigitAt(int)}
      */

--- a/src/test/java/hudson/util/VersionNumberTest.java
+++ b/src/test/java/hudson/util/VersionNumberTest.java
@@ -87,4 +87,14 @@ public class VersionNumberTest extends TestCase {
         assertEquals(-1, new VersionNumber("").getDigitAt(-1));
         assertEquals(-1, new VersionNumber("").getDigitAt(0));
     }
+
+    public void testOrEqualTo() {
+        assertTrue(new VersionNumber("1.8").isNewerOrEqualTo(new VersionNumber("1.8")));
+        assertTrue(new VersionNumber("1.9").isNewerOrEqualTo(new VersionNumber("1.8")));
+        assertTrue(new VersionNumber("2").isNewerOrEqualTo(new VersionNumber("1.8")));
+
+        assertTrue(new VersionNumber("1.8").isOlderOrEqualTo(new VersionNumber("1.8")));
+        assertTrue(new VersionNumber("1.7").isOlderOrEqualTo(new VersionNumber("1.8")));
+        assertTrue(new VersionNumber("1").isOlderOrEqualTo(new VersionNumber("1.8")));
+    }
 }


### PR DESCRIPTION
More readable than falling back to using `compareTo`.

@jglick as current maintainer, cc @jenkinsci/java11-support