### PR TITLE
Support Java 20 class version

### DIFF
--- a/src/main/java/io/jenkins/lib/versionnumber/JavaSpecificationVersion.java
+++ b/src/main/java/io/jenkins/lib/versionnumber/JavaSpecificationVersion.java
@@ -74,6 +74,7 @@ public class JavaSpecificationVersion extends VersionNumber {
         releaseToClass.put(17, 61);
         releaseToClass.put(18, 62);
         releaseToClass.put(19, 63);
+        releaseToClass.put(20, 64);
         RELEASE_TO_CLASS = Collections.unmodifiableNavigableMap(releaseToClass);
 
         NavigableMap<Integer, Integer> classToRelease = new TreeMap<>();


### PR DESCRIPTION
I verified when compiling some code with an Early Access build of Java 20 that the class version was 64, so it seems like we should support that here proactively.