### PR TITLE
Make class version logic more robust

### DIFF
--- a/src/main/java/io/jenkins/lib/versionnumber/JavaSpecificationVersion.java
+++ b/src/main/java/io/jenkins/lib/versionnumber/JavaSpecificationVersion.java
@@ -123,18 +123,29 @@ public class JavaSpecificationVersion extends VersionNumber {
      *
      * @param classVersion The class version; e.g., 52, 55, or 61.
      * @return The {@link JavaSpecificationVersion}; e.g., 1.8, 11, or 17.
+     * @throws IllegalArgumentException If the Java specification version for the given class version is unknown.
      */
     public static JavaSpecificationVersion fromClassVersion(int classVersion) {
-        return fromReleaseVersion(CLASS_TO_RELEASE.get(classVersion));
+        Integer releaseVersion = CLASS_TO_RELEASE.get(classVersion);
+        if (releaseVersion == null) {
+            throw new IllegalArgumentException("Unknown Java specification version for class version: " + classVersion);
+        }
+        return fromReleaseVersion(releaseVersion);
     }
 
     /**
      * Get the corresponding class file version.
      *
      * @return The class file version; e.g., 52, 55, or 61.
+     * @throws IllegalArgumentException If the class version for the given Java Specification Version is unknown.
      */
     public int toClassVersion() {
-        return RELEASE_TO_CLASS.get(toReleaseVersion());
+        int releaseVersion = toReleaseVersion();
+        Integer classVersion = RELEASE_TO_CLASS.get(releaseVersion);
+        if (classVersion == null) {
+            throw new IllegalArgumentException("Unknown class version for release version: " + releaseVersion);
+        }
+        return classVersion;
     }
 
     @NonNull

--- a/src/test/java/io/jenkins/lib/versionnumber/JavaSpecificationVersionTest.java
+++ b/src/test/java/io/jenkins/lib/versionnumber/JavaSpecificationVersionTest.java
@@ -101,10 +101,14 @@ public class JavaSpecificationVersionTest {
         assertEquals(new JavaSpecificationVersion("1.8"), JavaSpecificationVersion.fromClassVersion(52));
         assertEquals(new JavaSpecificationVersion("11"), JavaSpecificationVersion.fromClassVersion(55));
         assertEquals(new JavaSpecificationVersion("17"), JavaSpecificationVersion.fromClassVersion(61));
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> JavaSpecificationVersion.fromClassVersion(1000));
+        assertEquals("Unknown Java specification version for class version: 1000", e.getMessage());
 
         assertEquals(52, new JavaSpecificationVersion("1.8").toClassVersion());
         assertEquals(55, new JavaSpecificationVersion("11").toClassVersion());
         assertEquals(61, new JavaSpecificationVersion("17").toClassVersion());
+        e = assertThrows(IllegalArgumentException.class, () -> new JavaSpecificationVersion("1000").toClassVersion());
+        assertEquals("Unknown class version for release version: 1000", e.getMessage());
     }
 
     public void assertSpecEquals(JavaSpecificationVersion version, String value) {


### PR DESCRIPTION
Noticed when reviewing https://github.com/jenkinsci/versioncolumn-plugin/pull/75: a bit of a contrived use case, but pathological inputs to these methods were resulting in a `NullPointerException` rather than a clean error message. This PR makes these methods more robust and improves the error message.