### PR TITLE
docs: Add missing javadoc for VersionNumber#digit method

### DIFF
--- a/src/main/java/hudson/util/VersionNumber.java
+++ b/src/main/java/hudson/util/VersionNumber.java
@@ -545,6 +545,11 @@ public class VersionNumber implements Comparable<VersionNumber> {
     }
 
     /**
+     * Returns a digit (numeric component) by its position. Once a non-numeric component is found all remaining components
+     * are also considered non-numeric by this method.
+     *
+     * @param idx Digit position we want to retrieve starting by 0.
+     * @return The digit or -1 in case the position does not correspond with a digit.
      * @deprecated see {@link #getDigitAt(int)}
      */
     @Deprecated


### PR DESCRIPTION
This shows up as a warning during the build.
Though the method is deprecated, it's worth documenting it.

See: https://github.com/jenkinsci/gradle-jpi-plugin/pull/241#issuecomment-2661581217

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
